### PR TITLE
Feature: API Rest

### DIFF
--- a/server/__tests__/helpers/index.js
+++ b/server/__tests__/helpers/index.js
@@ -17,6 +17,13 @@ module.exports = {
   fixtures: {
     resourceList,
     resourceValidId,
-    resourceUselessId
+    resourceUselessId,
+    createResourceData: {
+      url: 'https://stackoverflow.com/',
+      title: 'Stackoverflow community'
+    },
+    updateResourceData: {
+      title: 'new title'
+    },
   }
 }

--- a/server/__tests__/helpers/index.js
+++ b/server/__tests__/helpers/index.js
@@ -1,4 +1,5 @@
 const resourceModel = require('../../stores/schemas/resource')
+const { errorsDescription: errors } = require('../../utils')
 
 const resourceValidId = '1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed'
 const resourceUselessId = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
@@ -25,5 +26,6 @@ module.exports = {
     updateResourceData: {
       title: 'new title'
     },
+    errors
   }
 }

--- a/server/__tests__/resource.test.js
+++ b/server/__tests__/resource.test.js
@@ -13,11 +13,7 @@ afterAll(resetDb)
 describe('STORE: resource model', () => {
   describe('create', () => {
     test('Should store a new resource', async () => {
-      const resourceData = {
-        url: 'https://stackoverflow.com/',
-        title: 'Stackoverflow community'
-      }
-
+      const resourceData = fixtures.createResourceData
       const createdResource = await Resource.create(resourceData)
       expect(createdResource.url).toEqual(resourceData.url)
       expect(createdResource.title).toEqual(resourceData.title)
@@ -30,7 +26,6 @@ describe('STORE: resource model', () => {
     })
 
     test('Should not store a new resource if data is wrong', async () => {
-
       try {
         await Resource.create(emptyData)
       } catch (e) {
@@ -73,7 +68,7 @@ describe('STORE: resource model', () => {
       await addResources()
       const updatedResource = await Resource.update(
         fixtures.resourceValidId,
-        { title: 'new title' }
+        fixtures.updateResourceData
       )
       expect(updatedResource.title).toEqual('new title')
 
@@ -85,7 +80,7 @@ describe('STORE: resource model', () => {
       await addResources()
       const updatedResource = await Resource.update(
         fixtures.resourceUselessId,
-        { title: 'new title' }
+        fixtures.updateResourceData
       )
       expect(updatedResource).toEqual(null)
 

--- a/server/__tests__/server.test.js
+++ b/server/__tests__/server.test.js
@@ -1,9 +1,155 @@
+require('dotenv').config()
 const request = require('supertest')
 const { app } = require('../server')
+const dbName = process.env.DB_NAME
+const dbUrl = process.env.DB_URL
+const { Resource, dbInit } = require('../stores')
+const { addResources, resetDb, fixtures } = require('./helpers')
 
-describe('Http server test', () => {
-  test('It should response the GET method', async () => {
-    const response = await request(app).get('/')
-    expect(response.statusCode).toBe(200)
+const emptyData = {}
+
+beforeAll(() => dbInit(dbUrl, dbName))
+beforeEach(resetDb)
+afterAll(resetDb)
+
+describe('Api server test', () => {
+  describe('[GET] api/v1/resources', () => {
+    test('Should return an array of resources stored', async () => {
+      await addResources()
+      const response = await request(app).get('/api/v1/resources')
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toEqual(fixtures.resourceList)
+    })
+
+    test('Should return an empty array if no resources are stored', async () => {
+      const response = await request(app).get('/api/v1/resources')
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toEqual([])
+    })
+  })
+
+  describe('[GET] api/v1/resources/:id', () => {
+    test('Should return the details of a stored resource', async () => {
+      await addResources()
+      const response = await request(app).get(`/api/v1/resources/${fixtures.resourceValidId}`)
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toEqual(fixtures.resourceList[0])
+    })
+
+    test('Should return a 404 error if the resource does not exist', async () => {
+      const response = await request(app).get(`/api/v1/resources/${fixtures.resourceUselessId}`)
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(404)
+      expect(response.body).toEqual(fixtures.errors.notFound)
+    })
+  })
+
+  describe('[POST] api/v1/resources', () => {
+    test('Should create and store a resource', async () => {
+      const resourceData = fixtures.createResourceData
+
+      const response = await request(app)
+        .post('/api/v1/resources')
+        .send(resourceData)
+        .set('Accept', 'application/json')
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(200)
+      expect(response.body.url).toEqual(resourceData.url)
+      expect(response.body.title).toEqual(resourceData.title)
+
+      const storedResources = await Resource.fetchAll()
+      expect(storedResources).toHaveLength(1)
+      expect(storedResources[0].url).toEqual(resourceData.url)
+      expect(storedResources[0].title).toEqual(resourceData.title)
+    })
+
+    test('Should not create or store a resouce if the payload is wrong', async () => {
+      const response = await request(app)
+        .post('/api/v1/resources')
+        .send(emptyData)
+        .set('Accept', 'application/json')
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(400)
+      expect(response.body).toEqual(fixtures.errors.genericError)
+
+      const storedResources = await Resource.fetchAll()
+      expect(storedResources).toHaveLength(0)
+    })
+  })
+
+  describe('[PUT] api/v1/resources/:id', () => {
+    const resourceData = fixtures.updateResourceData
+
+    test('Should update a resource if the data is correct', async () => {
+      await addResources()
+
+      const response = await request(app)
+        .put(`/api/v1/resources/${fixtures.resourceValidId}`)
+        .send(resourceData)
+        .set('Accept', 'application/json')
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(200)
+      expect(response.body.title).toEqual(resourceData.title)
+
+      const storedResources = await Resource.fetchOne(fixtures.resourceValidId)
+      expect(storedResources.title).toEqual(resourceData.title)
+    })
+
+    test('Should not update a resouce if the id is wrong', async () => {
+      await addResources()
+
+      const response = await request(app)
+        .put(`/api/v1/resources/${fixtures.resourceUseLessId}`)
+        .send(resourceData)
+        .set('Accept', 'application/json')
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(404)
+      expect(response.body).toEqual(fixtures.errors.notFound)
+
+      const storedResources = await Resource.fetchAll()
+      expect(storedResources).toEqual(fixtures.resourceList)
+    })
+
+    test('Should not update a resouce if the payload is wrong', async () => {
+      await addResources()
+
+      const response = await request(app)
+        .put(`/api/v1/resources/${fixtures.resourceValidId}`)
+        .send(emptyData)
+        .set('Accept', 'application/json')
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toEqual(fixtures.resourceList[0])
+
+      const storedResources = await Resource.fetchAll()
+      expect(storedResources).toEqual(fixtures.resourceList)
+    })
+  })
+
+  describe('[DELETE] api/v1/resources/:id', () => {
+    test('Should delete the details of a stored resource and returns the deleted resource', async () => {
+      await addResources()
+      const response = await request(app).delete(`/api/v1/resources/${fixtures.resourceValidId}`)
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(200)
+      expect(response.body).toEqual(fixtures.resourceList[0])
+
+      const storedResources = await Resource.fetchAll()
+      expect(storedResources).toHaveLength(1)
+    })
+
+    test('Should return a 404 error if the resource does not exist', async () => {
+      await addResources()
+      const response = await request(app).delete(`/api/v1/resources/${fixtures.resourceUselessId}`)
+      expect(response.res.headers['content-type']).toMatch('application/json')
+      expect(response.statusCode).toBe(404)
+      expect(response.body).toEqual(fixtures.errors.notFound)
+
+      const storedResources = await Resource.fetchAll()
+      expect(storedResources).toHaveLength(2)
+    })
   })
 })

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/KoolTheba/read-dojo#readme",
   "devDependencies": {},
   "dependencies": {
+    "body-parser": "^1.19.0",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/server/server.js
+++ b/server/server.js
@@ -1,11 +1,67 @@
 const express = require('express')
 const helmet = require('helmet')
+const bodyParser = require('body-parser')
 const app = express()
+const { Resource } = require('./stores')
+const { successHandler, errorsDescription } = require('./utils')
 
+app.use(bodyParser.json())
 app.use(helmet())
 
-app.get('/', (req, res) => {
-  res.send('Hello World!')
+app.get('/api/v1/resources', async (req, res, next) => {
+  try {
+    const resources = await Resource.fetchAll()
+    return successHandler(res, resources)
+  } catch (err) {
+    next(errorsDescription.genericError)
+  }
+})
+
+app.get('/api/v1/resources/:resourceId', async (req, res, next) => {
+  try {
+    const { resourceId } = req.params
+    const resource = await Resource.fetchOne(resourceId)
+    return resource ? successHandler(res, resource) : next(errorsDescription.notFound)
+  } catch (err) {
+    next(errorsDescription.genericError)
+  }
+})
+
+app.post('/api/v1/resources', async (req, res, next) => {
+  try {
+    const { body } = req
+    const resource = await Resource.create(body)
+    return successHandler(res, resource)
+  } catch (err) {
+    next(errorsDescription.genericError)
+  }
+})
+
+app.put('/api/v1/resources/:resourceId', async (req, res, next) => {
+  try {
+    const { body, params: { resourceId } } = req
+    const resource = await Resource.update(resourceId, body)
+    return resource ? successHandler(res, resource) : next(errorsDescription.notFound)
+  } catch (err) {
+    next(errorsDescription.genericError)
+  }
+})
+
+app.delete('/api/v1/resources/:resourceId', async (req, res, next) => {
+  try {
+    const { resourceId } = req.params
+    const resource = await Resource.delete(resourceId)
+    return resource ? successHandler(res, resource) : next(errorsDescription.notFound)
+  } catch (err) {
+    next(errorsDescription.genericError)
+  }
+})
+
+app.use((err, req, res, next) => {
+  return res.status(err.status || 400).json({
+    status: err.status || 400,
+    message: err.message || 'there was an error processing request'
+  })
 })
 
 module.exports = {

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -1,0 +1,10 @@
+const successHandler = (res, payload) => res.status(200).json(payload)
+const errorsDescription = {
+  notFound: { status: 404, message: 'not found' },
+  genericError: { status: 400, message: 'failed to get resources' }
+}
+
+module.exports = {
+  successHandler,
+  errorsDescription
+}


### PR DESCRIPTION
### Main Changes
- Added API Rest for resources CRUD operations (bf5ed65) and integration tests (5871eb7)
  - Added route: `[GET] api/v1/resources`
  - Added route: `[GET] api/v1/resources/:id`
  - Added route: `[POST] api/v1/resources`
  - Added route: `[PUT] api/v1/resources/:id`
  - Added route: `[DELETE] api/v1/resources/:id'`

### Other changes
- Added dependency `body-parser@^1.19.0` (46fc976)
- Refactored fixtures to avoid hardcoded data in tests (1b9b656)

### Notes
#### Test coverage
- Up to 90% server coverage 💪 
![Captura de pantalla 2020-08-10 a las 19 42 55](https://user-images.githubusercontent.com/26543236/89813655-4d559400-db42-11ea-96e7-7a3e3f2b42b7.png)

### Context
- Related #12 

### Changelog
- 46fc976 chore(server): Added body-parser dependency by @KoolTheba 
- 1b9b656 refactor(server): Relocated hardcoded data in tests to fixtures by @KoolTheba
- bf5ed65 feat(server): Added apirest for resources CRUD ops by @KoolTheba
- 5871eb7 feat(server): Added tests for apirest CRUD ops by @KoolTheba 




